### PR TITLE
Updated et-launcher app

### DIFF
--- a/scripts/install-et-launcher.sh
+++ b/scripts/install-et-launcher.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-ET_LAUNCHER_APP_DL="https://github.com/clifjones/et-launcher/releases/download/app-v0.3.0-20-12b16ae/et-launcher_0.3.0_amd64.AppImage"
+ET_LAUNCHER_APP_DL="https://github.com/clifjones/et-launcher/releases/download/app-v0.3.0-24-95bfb42/et-launcher_0.3.0_amd64.AppImage" 
 DEST_DIR="/opt/appimages"
 DEST_FILE="${DEST_DIR}/et-launcher.appimage"
 


### PR DESCRIPTION
Updated et-launcher app to have better note handling if there is no information for radio notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update et-launcher AppImage download URL to app-v0.3.0-24-95bfb42 in `scripts/install-et-launcher.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 763d9af0c8f77f2ddfad6c966d0aaee1bb4759af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->