### PR TITLE
Update emcomm-tools-community to release/r6 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "emcomm-tools-os-community"]
 	path = emcomm-tools-os-community
-	url = https://github.com/clifjones/emcomm-tools-os-community
+	url = https://github.com/thetechprepper/emcomm-tools-os-community
 [submodule]
-	emcomm-tools-os-community = release/r5
+	emcomm-tools-os-community = release/r6


### PR DESCRIPTION
Stop tracking forked version of emcomm-tools-community and move to release/r6 branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Points the emcomm-tools-os-community submodule to the thetechprepper repo and switches tracking from release/r5 to release/r6.
> 
> - **Submodules**:
>   - **`.gitmodules`**:
>     - Update `emcomm-tools-os-community` URL to `https://github.com/thetechprepper/emcomm-tools-os-community`.
>     - Change tracked branch from `release/r5` to `release/r6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac37824098a36d093aab5c60e3aabbed5bffb4b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->