### PR TITLE
Added a git submodule check to simplify install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,6 @@
 [submodule "emcomm-tools-os-community"]
 	path = emcomm-tools-os-community
 	url = https://github.com/thetechprepper/emcomm-tools-os-community
+	branch = release/r6
 [submodule]
 	emcomm-tools-os-community = release/r6

--- a/README.md
+++ b/README.md
@@ -2,24 +2,27 @@
 These add-on extend [EmComm Tools OS Community](https://github.com/thetechprepper/emcomm-tools-os-community) to contain popular radio packet tools not in the original distribution. This can be useful if you want to practice using your offline emcomm appliance out in the field with more popular modes like FT8 during POTA/SOTA operations.
 
 ## Installation
-There are two ways to install `et-os-addons` depending on your workflow. You can either update your existing installation, or you can do it as part of building an image for use on an offline appliance. Either way will work but the process is different for each.
+Install [Cubic](https://github.com/PJ-Singh-001/Cubic) and start a new session using the Ubuntu 2.10 install image.
 
-### 1) Existing EmComm Tools Installation
+Download `et-os-addons` instead of `emcomm-tools-community` during ***Step 8*** of the [Creating EmComm Tools Community Image](https://community.emcommtools.com/getting-stated/create-etc-image.html) page. Replace the download URL in that section with:
 
-1. Follow the instructions in the [EmComm Tools OS Community](https://community.emcommtools.com/getting-stated/) wiki to build a bootable image. When you're done either install that image on your machine or just boot from it, either way is fine.
-1. While booted from that image first create a working folder from which to build `et-os-addons`. It's fine to just make a `temp` folder in your `~/home` directory for this.
-1. `cd` into the directory then clone `et-os-addons` with the following command:
-    - `git clone --recurse-submodules https://github.com/clifjones/et-os-addons.git`
-    - NOTE: DO NOT just use `git clone` or you won't have the necessary `emcomm-tools-community` submodules that are required to update your installation.
+`https://github.com/clifjones/et-os-addons/archive/refs/heads/main.tar.gz`
 
-***Note:*** *To run a future update from this directory use `git submodule update --init --recursive` from the root `et-os-addons` repo.*
+Note: `et-os-addons` contains a specific branch of [EmComm Tools Community](https://github.com/thetechprepper/emcomm-tools-os-community) as a Git submodule. The install script will check and attempt to properly sync this submodule repo during the build if you "clone" the repo. If you download the repo as a `zip` or `tar.gz` file, the submodule installer will attempt to download a tar file of `emcomm-tools-community` and expand it properly in the designated `et-os-addons` subdirectory.
 
-### 2) While Building New Image
-To add `et-os-addons` while building an image of EmComm Tools for a new installation you'll need to use the download for `et-os-addons` instead of `emcomm-tools` during ***Step 8*** of the [Creating EmComm Tools Community Image](https://community.emcommtools.com/getting-stated/create-etc-image.html) page. Replace the download URL in that section with:
+### Summary of Build Steps
+1. Start an Ubuntu 2.10 Cubic customization session
+2. Download a zip or tar file of [this repo](https://github.com/clifjones/et-os-addons)
+3. Copy the resulting repo archive into the Cubic session and return to the customization shell
+4. Unzip or Untar the archive into the home directory
+5. Change directory to the et-os-addons repo copy with command: `cd et-os-addons`
+6. Execute the install script with command: `scripts/install.sh`
+7. Ensure that the build completes without error and displays the final test status with all tests passing
+8. Complete the customized Ubuntu installer process
 
-`https://github.com/clifjones/et-os-addons/archive/refs/heads/main.zip`
-
-You will need to use `unzip` command instead of `tar` for this step. The rest of the process is the same.
+### Important Build Notes
+* `emcomm-tools-community` Git repo now contains symbolic file links, which is **NOT** compatible with the `zip` file format. TL;DR: Use `tar`. `et-os-addons` currently be downloaded as a `zip` or `tar.gz` file without issue as it will properly add in `emcomm-tools-community` as a `tar.gz` download.
+* Some builds of `emcomm-tools-community` exit in error with `dpkg` unmet dependency problems (ex. SDR++ install test fails). Correct the build by running `apt install --fix-broken -y` and re-running the affected install script and re-verifying by re-running the test scripts.
 
 ---
 
@@ -50,3 +53,4 @@ et-os-addons adds the following enhancements to [EmComm Tools OS Community](http
 - Added prototype Saildocs weather map retrieval scripts
 - Added QSSTV and Cheese for webcam and SSTV support
 - Added support for the [Blue Ridge Amateur Radio Society NetControl app](https://brars.cc/). (Requires Wine and application install)
+- No longer require cloning of the repo to install. Install scripts will add in `emcomm-tools-community` using the `git` command or `wget` depending on the download method automatically.

--- a/overlay/etc/apt/sources.list
+++ b/overlay/etc/apt/sources.list
@@ -1,0 +1,14 @@
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic main restricted
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic-updates main restricted
+
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic universe
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic-updates universe
+
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic-updates multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu/ kinetic-backports main restricted universe multiverse
+
+deb http://old-releases.ubuntu.com/ubuntu kinetic-security main restricted
+deb http://old-releases.ubuntu.com/ubuntu kinetic-security universe
+deb http://old-releases.ubuntu.com/ubuntu kinetic-security multiverse

--- a/scripts/init-submodules.sh
+++ b/scripts/init-submodules.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Author: Clifton Jones (KD4CTJ)
+# Description:
+#   Initialize git submodules
+#
+
+# Exit on error
+set -o errexit
+set -o pipefail
+
+# Ensure git submodules are properly initialized and synced with remote origin
+SCRIPT_DIR="$(dirname $(readlink -f $0))"
+REPO_ROOT="$(readlink -f ${SCRIPT_DIR}/..)"
+TEMP_DIR=""
+
+# Cleanup function
+cleanup() {
+  if [ -n "${TEMP_DIR}" ] && [ -d "${TEMP_DIR}" ]; then
+    rm -rf "${TEMP_DIR}"
+  fi
+}
+
+# Trap to handle errors and cleanup
+trap 'cleanup; exit 1' ERR
+trap 'cleanup' EXIT
+# Ensure git and wget is installed
+cp -v ${REPO_ROOT}/overlay/etc/apt/sources.list /etc/apt/
+apt update
+apt install git wget -y
+[ $? -ne 0 ] && echo "Error installing git or wget" && exit 1
+
+# Check repo install method and initialize submodules accordingly
+if [ -e ${REPO_ROOT}/.git/config ]; then
+  # Git repo
+  echo -ne "\n\n"
+  echo "*** Git repo detected. Syncing submodule URLs... ***"
+  echo -ne "\n\n"
+  sleep 2
+  (cd "${REPO_ROOT}" && git submodule sync --recursive)
+  echo "Initializing and updating git submodules..."
+  (cd "${REPO_ROOT}" && git submodule update --init --recursive --remote)
+else
+  # Tarball repo
+  TEMP_DIR="$(mktemp -d)"
+
+  # Parse .gitmodules to get URL and branch, then create tarball URL
+  ETC_REPO_URL="$(git config -f ${REPO_ROOT}/.gitmodules --get submodule.emcomm-tools-os-community.url)"
+  ETC_REPO_BRANCH="$(git config -f ${REPO_ROOT}/.gitmodules --get submodule.emcomm-tools-os-community.branch)"
+  ETC_REPO_TARBALL_URL="${ETC_REPO_URL}/archive/refs/heads/${ETC_REPO_BRANCH}.tar.gz"
+
+  echo -ne "\n\n"
+  echo "*** Tarball repo detected. Initializing submodules from ${ETC_REPO_TARBALL_URL} ***"
+  echo -ne "\n\n"
+  sleep 2
+  wget -O ${TEMP_DIR}/emcomm-tools-os-community.tar.gz ${ETC_REPO_TARBALL_URL}
+  tar -xzf ${TEMP_DIR}/emcomm-tools-os-community.tar.gz -C ${TEMP_DIR}
+  cp -r ${TEMP_DIR}/emcomm-tools-os-community-*/* ${REPO_ROOT}/emcomm-tools-os-community/.
+  cleanup && echo "Submodules initialized successfully"
+fi

--- a/scripts/install-gridtracker.sh
+++ b/scripts/install-gridtracker.sh
@@ -10,7 +10,7 @@
 
 set -e 
 
-GRIDTRACKER2_DEB_DL="https://download2.gridtracker.org/GridTracker2-2.250901.0-amd64.deb"
+GRIDTRACKER2_DEB_DL="https://download2.gridtracker.org/GridTracker2-2.250914.1-amd64.deb"
 TMP_FILE="/tmp/gridtracker2-tmp.deb"
 
 function cleanup() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,12 @@
 #   Install emcomm-tools-os-community then installs additional tools
 #
 
+# Define SCRIPTS_DIR before using it
+SCRIPTS_DIR="$(dirname $(readlink -f $0))"
+
+# Initialize git submodules
+${SCRIPTS_DIR}/init-submodules.sh
+
 # Load env
 . $(dirname $(readlink -f $0))/../scripts/env.sh
 

--- a/scripts/pre-install.sh
+++ b/scripts/pre-install.sh
@@ -2,7 +2,7 @@
 #
 # Author: Clifton Jones (KD4CTJ)
 # Description:
-#   Make additional changes to the desktop, such as default X server and Gnome overrides
+#   Initialize build directories, etc.
 #
 
 # Load env if this script executed individually


### PR DESCRIPTION
Updated pre-install script to ensure that emcomm-tools-community is up to date. 
Updated README
Updated Gridtracker 2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated submodule setup and tarball-based install support, plus minor updates.
> 
> - Adds `scripts/init-submodules.sh` to detect clone vs tarball, install `git/wget`, set `apt` sources from `overlay/etc/apt/sources.list`, and fetch `emcomm-tools-os-community` (via `git submodule update` or tarball per `.gitmodules` branch `release/r6`)
> - `scripts/install.sh` now runs `init-submodules.sh` first; minor pre-install cleanup and env/load ordering
> - New `overlay/etc/apt/sources.list` pinning Ubuntu kinetic to old-releases mirrors
> - README rewritten to document Cubic-based flow and non-clone installs; notes about tar vs zip and dependency fixes
> - Bumps GridTracker 2 package to `2.250914.1`
> - Updates `.gitmodules` to track submodule branch `release/r6`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59c6cf716a931a4c6ba75d6ff8823858eaefa0b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->